### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/pandora_cas/manifest.json
+++ b/custom_components/pandora_cas/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "pandora_cas",
   "name": "Pandora Car Alarm System",
-  "version": "2021.6.0",
+  "version": "0.0.4",
   "documentation": "https://github.com/alryaz/pandora-cas",
   "issue_tracker": "https://github.com/alryaz/pandora-cas/issues",
   "dependencies": [],

--- a/custom_components/pandora_cas/manifest.json
+++ b/custom_components/pandora_cas/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "pandora_cas",
   "name": "Pandora Car Alarm System",
+  "version": "2021.6.0",
   "documentation": "https://github.com/alryaz/pandora-cas",
   "issue_tracker": "https://github.com/alryaz/pandora-cas/issues",
   "dependencies": [],


### PR DESCRIPTION
Add "version" key
The version key is required from Home Assistant version 2021.6