### PR TITLE
Fix compatibility issue with 2023.09

### DIFF
--- a/custom_components/pandora_cas/entity.py
+++ b/custom_components/pandora_cas/entity.py
@@ -160,10 +160,11 @@ class BasePandoraCASEntity(Entity):
         d = self.pandora_device
         return DeviceInfo(
             identifiers={(DOMAIN, str(d.device_id))},
-            default_name=d.name,
+            name=d.name,
             manufacturer="Pandora",
             model=d.model,
             sw_version=f"{d.firmware_version} / {d.voice_version}",
+            via_device=(DOMAIN, str(d.device_id))
         )
 
 


### PR DESCRIPTION
Component is not starting on 2023.09 with error message "config entry: device info needs to either describe a device, link to existing device or provide extra information."
https://developers.home-assistant.io/docs/device_registry_index?_highlight=deviceinfo#automatic-registration-through-an-entity page state that via_device is mandatory and name should be used instead of default_name